### PR TITLE
Fix yall.js path in plugin.json

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -3,6 +3,6 @@
 	"title": "All photos",
 	"description": "Changes the Photos page to include all photos in multi-photo posts, not just first photo.",
 	"includes": [
-		"/css/yall.js"
+		"/js/yall.js"
 	]
 }


### PR DESCRIPTION
This file was moved, but the plugin configuration was never changed to reflect that; micro.blog sites that currently use this plugin end up getting a 404 when trying to load `/css/yall.js`.